### PR TITLE
Fix HTTPS redirect port

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -9,6 +9,7 @@ events {
 
 env JWT_PUBLIC;
 env INFLUX_API_KEY;
+env PLACE_DOMAIN;
 
 http {
   include /usr/local/openresty/nginx/conf/mime.types;
@@ -41,7 +42,8 @@ http {
   server {
     listen 80 default_server;
     server_name _;
-    return 301 https://$host$request_uri;
+    set_by_lua $place_domain 'return os.getenv("PLACE_DOMAIN")';
+    return 301 https://$place_domain$request_uri;
   }
 
   server {
@@ -56,7 +58,7 @@ http {
 
     location / {
         root /etc/nginx/html;
-        try_files $uri $uri/ =404;
+        try_files $uri $uri/index.html =404;
     }
 
     location /api/ {

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -56,7 +56,7 @@ http {
 
     location / {
         root /etc/nginx/html;
-        try_files $uri $uri/index.html =404;
+        try_files $uri $uri/ =404;
     }
 
     location /api/ {

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -9,7 +9,7 @@ events {
 
 env JWT_PUBLIC;
 env INFLUX_API_KEY;
-env PLACE_DOMAIN;
+env HTTPS_REDIRECT_PORT;
 
 http {
   include /usr/local/openresty/nginx/conf/mime.types;
@@ -42,8 +42,8 @@ http {
   server {
     listen 80 default_server;
     server_name _;
-    set_by_lua $place_domain 'return os.getenv("PLACE_DOMAIN")';
-    return 301 https://$place_domain$request_uri;
+    set_by_lua $https_redirect_port 'return os.getenv("HTTPS_REDIRECT_PORT")';
+    return 301 https://$host:$https_redirect_port$request_uri;
   }
 
   server {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,5 +18,12 @@ if [ ! -d "${nginx_config}/ssl" ]; then
   openssl dhparam -out "${nginx_config}/ssl/dhparam.pem" 1024
 fi
 
+# Extract the port to use when upgrading connection to HTTPS if it has not been
+# explicitly set. This port may differ from the local HTTPS when remapped within
+# different deployment environments.
+if [ -z ${HTTPS_REDIRECT_PORT+x} ]; then
+  export HTTPS_REDIRECT_PORT=${PLACE_DOMAIN#*:}
+fi
+
 # Start OpenResty
 /usr/local/openresty/bin/openresty -c "${nginx_config}/nginx.conf"


### PR DESCRIPTION
Adds support operating on externally remapped ports without breaking things when upgrading from http -> https.

A `HTTPS_REDIRECT_PORT` environment variable can be used to explicitly specify this. If unset, default to the port component of `PLACE_DOMAIN` that is used for SSL cert generation.

Resolves #1.