### PR TITLE
feat(chronograf): replace influxdb with chronograf

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -43,12 +43,12 @@ http {
     ssl_dhparam /etc/nginx/ssl/dhparam.pem;
 
     resolver 127.0.0.11 valid=10s;
-    set $api      api:3000;
-    set $auth     auth:8080;
-    set $dispatch dispatch:8086;
-    set $staff    staff:8080;
-    set $influx   influx:9999;
-    set $kibana   kibana:5601;
+    set $api          api:3000;
+    set $auth         auth:8080;
+    set $dispatch     dispatch:8086;
+    set $staff        staff:8080;
+    set $chronograf   chronograf:8888;
+    set $kibana       kibana:5601;
     
     location ~ /\. {
       deny all;
@@ -108,23 +108,13 @@ http {
       proxy_read_timeout 2m;
     }
 
-    location /influxdb/ {
-      access_by_lua_file  /bearer.lua;
-      proxy_pass  http://$influx/;
-
-      set_by_lua $influxdb_token 'return "Token " .. os.getenv("INFLUX_API_KEY")';
-      proxy_set_header Authorization $influxdb_token;
-      proxy_redirect   off;
-      proxy_http_version 1.1;
-      proxy_set_header Host $http_host;
+    location /analytics/ {
+      proxy_pass  http://$chronograf;
+      proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto https;
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
       proxy_connect_timeout 1m;
       proxy_send_timeout 2m;
-      proxy_read_timeout 2m;
+      proxy_read_timeout 5m;
     }
 
     location /monitor/ {


### PR DESCRIPTION
Chronograf is unfortunately required because:
- InfluxDBv2 frontend currently does [not support](https://github.com/influxdata/influxdb/issues/15721) a custom base href (e.g. [/influxdb](https://github.com/PlaceOS/nginx/blob/main/config/nginx.conf#L111)). When I tested influxdbv2, it worked fine at / withit's own subdomain, but I could not get it to work under any subdirectory - essential API calls would be made to an incorrect path.
- InfluxDBv2 OSS does not support OAuth, so we won't be able to use it's frontend for production deployments

The change in this PR is a prerequisite of https://github.com/place-labs/partner-environment/pull/80