### PR TITLE
feat(nginx.conf): add upstream websocket mqtt broker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM openresty/openresty:alpine-fat
+FROM openresty/openresty:1.19.9.1-alpine-fat
 
-RUN apk add --no-cache openssl
+RUN apk add --no-cache openssl git
 
 # TODO: install lua-resty-jwt then base off a smaller open-resty image
 RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-jwt

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -49,6 +49,7 @@ http {
     set $staff        staff:8080;
     set $chronograf   chronograf:8888;
     set $kibana       kibana:5601;
+    set $mosquitto    mosquitto:9001;
     
     location ~ /\. {
       deny all;
@@ -90,6 +91,10 @@ http {
 
         location /api/staff/ {
           proxy_pass  http://$staff;
+        }
+        
+        location /api/mqtt/ {
+          proxy_pass  http://$mosquitto/;
         }
     }
 

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -50,7 +50,7 @@ http {
     set $chronograf   chronograf:8888;
     set $kibana       kibana:5601;
     set $mosquitto    mosquitto:9001;
-    
+
     location ~ /\. {
       deny all;
     }
@@ -92,7 +92,7 @@ http {
         location /api/staff/ {
           proxy_pass  http://$staff;
         }
-        
+
         location /api/mqtt/ {
           proxy_pass  http://$mosquitto/;
         }


### PR DESCRIPTION
Adds an `/api/mqtt` endpoint that forwards to a local `mosquitto:9001` where there may be an instance of mosquitto with go-auth plugin configured for JWT auth via the local placeos rest-api service.

The mosquitto.conf would be configured to use jwt_remote authentication: https://github.com/iegomez/mosquitto-go-auth#remote-mode

The setup is undergoing e2e testing in partner-environment using this docker image: https://hub.docker.com/r/iegomez/mosquitto-go-auth
with a mosquitto.conf that includes:
```
listener 9001
protocol websockets

include_dir /mosquitto
auth_plugin /mosquitto/go-auth.so
auth_opt_backends jwt
auth_opt_jwt_mode remote
auth_opt_jwt_host api
auth_opt_jwt_port 3000
auth_opt_jwt_getuser_uri /api/engine/v2/mqtt_user
auth_opt_jwt_aclcheck_uri /api/engine/v2/mqtt_access
auth_opt_jwt_response_mode status
auth_opt_jwt_params_mode form
```