### PR TITLE
chore(security): don't serve hidden files/folders like .git/

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -132,5 +132,10 @@ http {
             root /etc/nginx/html;
             try_files $uri $uri/index.html =404;
         }
+        
+        # Deny .* (e.g. .git/)
+        location ~ /\. {
+          deny all;
+        }
     }
 }


### PR DESCRIPTION
**Description of the change**

have nginx deny any requests to get files/folders that start with `.`
This include the `.git` folder inside all frontend repos, which an attacker could use to grab frontend source.
