### PR TITLE
style: use `$host` over `$http_host`

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -69,7 +69,7 @@ http {
             proxy_pass  http://$api;
             proxy_redirect   off;
             proxy_http_version 1.1;
-            proxy_set_header Host $http_host;
+            proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;
@@ -100,7 +100,7 @@ http {
             proxy_pass  http://$auth;
             proxy_redirect   off;
             proxy_http_version 1.1;
-            proxy_set_header Host $http_host;
+            proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;
@@ -117,7 +117,7 @@ http {
             proxy_pass  http://$kibana;
             proxy_redirect   off;
             proxy_http_version 1.1;
-            proxy_set_header Host $http_host;
+            proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;


### PR DESCRIPTION
**Description of the change**

This was recommended by the [`gixy`](https://github.com/yandex/gixy) tool to prevent HTTP host spoofing