### PR TITLE
fix(nginx.conf): add trailing / redirect to app requests

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -129,6 +129,10 @@ http {
         }
 
         location / {
+            absolute_redirect on;
+            if ($request_uri ~ ^([^.\?]*[^/])$) {
+              return 301 https://$http_host$uri/;
+            }
             root /etc/nginx/html;
             try_files $uri $uri/index.html =404;
         }

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -131,7 +131,7 @@ http {
         location / {
             absolute_redirect on;
             if ($request_uri ~ ^([^.\?]*[^/])$) {
-              return 301 https://$http_host$uri/;
+                return 301 https://$http_host$uri/;
             }
             root /etc/nginx/html;
             try_files $uri $uri/index.html =404;


### PR DESCRIPTION
Redirects, adding a trailing /, when the uri does not contain . ? or end with /

Tested in kubernetes and docker, backoffice and workplace app

Closes https://github.com/PlaceOS/backoffice/issues/263